### PR TITLE
Prevent pd.qcut from crashing

### DIFF
--- a/matchmaking.py
+++ b/matchmaking.py
@@ -147,7 +147,7 @@ class MatchMaking:
         `self.teamsize`.
         """
         self.df["skill_bin"], self.bins = pd.qcut(
-            self.df.skill, self.teamsize, retbins=True, labels=False
+            self.df.skill, self.teamsize, retbins=True, labels=False, duplicates='drop'
         )
         self.max_bin = self.df.skill_bin.max()
         self.min_bin = self.df.skill_bin.min()


### PR DESCRIPTION
If several players have the same skills, `pd.qcut` will crash. Adding `duplicates='drop'` prevent this crash.